### PR TITLE
infra: Remove the openssh commands from dockerfile

### DIFF
--- a/test/container/1.6.0/Dockerfile.dlc.cpu
+++ b/test/container/1.6.0/Dockerfile.dlc.cpu
@@ -1,17 +1,6 @@
 ARG region
 FROM 763104351884.dkr.ecr.$region.amazonaws.com/mxnet-training:1.6.0-cpu-py2
 
-# TODO @chai remove once DLC images have OpenSHH installed
-# OpenSHH config for MPI communication
-RUN mkdir -p /var/run/sshd && \
-  sed 's@session\s*required\s*pam_loginuid.so@session optional pam_loginuid.so@g' -i /etc/pam.d/sshd
-
-RUN rm -rf /root/.ssh/ && \
-  mkdir -p /root/.ssh/ && \
-  ssh-keygen -q -t rsa -N '' -f /root/.ssh/id_rsa && \
-  cp /root/.ssh/id_rsa.pub /root/.ssh/authorized_keys \
-  && printf "Host *\n StrictHostKeyChecking no\n" >> /root/.ssh/config
-
 COPY dist/sagemaker_mxnet_training-*.tar.gz /sagemaker_mxnet_training.tar.gz
 RUN pip install --upgrade --no-cache-dir /sagemaker_mxnet_training.tar.gz && \
     rm /sagemaker_mxnet_training.tar.gz

--- a/test/container/1.6.0/Dockerfile.dlc.gpu
+++ b/test/container/1.6.0/Dockerfile.dlc.gpu
@@ -1,17 +1,6 @@
 ARG region
 FROM 763104351884.dkr.ecr.$region.amazonaws.com/mxnet-training:1.6.0-gpu-py3
 
-# TODO @chai remove once DLC images have OpenSHH installed
-# OpenSHH config for MPI communication
-RUN mkdir -p /var/run/sshd && \
-  sed 's@session\s*required\s*pam_loginuid.so@session optional pam_loginuid.so@g' -i /etc/pam.d/sshd
-
-RUN rm -rf /root/.ssh/ && \
-  mkdir -p /root/.ssh/ && \
-  ssh-keygen -q -t rsa -N '' -f /root/.ssh/id_rsa && \
-  cp /root/.ssh/id_rsa.pub /root/.ssh/authorized_keys \
-  && printf "Host *\n StrictHostKeyChecking no\n" >> /root/.ssh/config
-
 COPY dist/sagemaker_mxnet_training-*.tar.gz /sagemaker_mxnet_training.tar.gz
 RUN pip install --upgrade --no-cache-dir /sagemaker_mxnet_training.tar.gz && \
     rm /sagemaker_mxnet_training.tar.gz


### PR DESCRIPTION
*Issue #, if available:*
Since DLC released with OpenSSH I am removing this addition as it's redundant now
Related comment: https://github.com/aws/sagemaker-mxnet-training-toolkit/pull/178/files#r441667892


*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.